### PR TITLE
Some small fixes, mainly for enabling commenting within Sublimetext.

### DIFF
--- a/Typeface development.tmbundle/Preferences/Comments.tmPreferences
+++ b/Typeface development.tmbundle/Preferences/Comments.tmPreferences
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Comments</string>
+	<key>scope</key>
+	<string>source.AFDKO</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string># </string>
+			</dict>
+		</array>
+	</dict>
+	<key>uuid</key>
+	<string>E2B2AABE-9C55-4BAF-A0B9-C9833AEEE943</string>
+</dict>
+</plist>

--- a/Typeface development.tmbundle/Preferences/Completions.tmPreferences
+++ b/Typeface development.tmbundle/Preferences/Completions.tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>name</key>
-	<string>Competions</string>
+	<string>Completions</string>
 	<key>scope</key>
 	<string>source.AFDKO</string>
 	<key>settings</key>

--- a/Typeface development.tmbundle/Syntaxes/AFDKO Features.tmLanguage
+++ b/Typeface development.tmbundle/Syntaxes/AFDKO Features.tmLanguage
@@ -52,7 +52,7 @@
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#depricated-keywords</string>
+			<string>#deprecated-keywords</string>
 		</dict>
 		<dict>
 			<key>include</key>
@@ -152,7 +152,7 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#depricated-keywords</string>
+					<string>#deprecated-keywords</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -211,12 +211,12 @@
 			<key>name</key>
 			<string>constant.numeric.AFDKO</string>
 		</dict>
-		<key>depricated-keywords</key>
+		<key>deprecated-keywords</key>
 		<dict>
 			<key>match</key>
 			<string>\b(exclude|include)DFLT</string>
 			<key>name</key>
-			<string>invalid.depricated.AFDKO</string>
+			<string>invalid.deprecated.AFDKO</string>
 		</dict>
 		<key>double-quoted-string</key>
 		<dict>
@@ -255,7 +255,7 @@
 		<key>glyph-class</key>
 		<dict>
 			<key>match</key>
-			<string>@[a-zA-Z0-9_-]+</string>
+			<string>@[a-zA-Z\.0-9_-]+</string>
 			<key>name</key>
 			<string>storage.type.class.AFDKO</string>
 		</dict>
@@ -395,7 +395,7 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#depricated-keywords</string>
+					<string>#deprecated-keywords</string>
 				</dict>
 				<dict>
 					<key>include</key>


### PR DESCRIPTION
Add Comments pref file (necessary for Sublimetext).
Include matching for period (.) in class name.
Fix small typos.
