### PR TITLE
Better recognition of numeric constants

### DIFF
--- a/Syntaxes/AFDKO Features.tmLanguage
+++ b/Syntaxes/AFDKO Features.tmLanguage
@@ -207,7 +207,7 @@
 		<key>constant-number</key>
 		<dict>
 			<key>match</key>
-			<string>(-|\+)?\s*[0-9]+(\.[0-9]+)?</string>
+			<string>\b(-|\+)?\s*[0-9]+(\.[0-9]+)?</string>
 			<key>name</key>
 			<string>constant.numeric.AFDKO</string>
 		</dict>


### PR DESCRIPTION
Add a word delimiter at the beginning to avoid recognition of numeric constants which are part of glyph names, class names etc.