### PR TITLE
Update link to FEA spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenType Feature Bundle for TextMate/Sublime Text
 
-This covers Adobe’s [OpenType Feature File Specification](https://www.adobe.com/devnet/opentype/afdko/topic_feature_file_syntax.html) used by the [AFDKO](https://github.com/adobe-type-tools/afdko). As well as syntax highlighting, there are also a couple of snippets for creating features, tables etc.
+This covers Adobe’s [OpenType Feature File Specification](https://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html) used by the [AFDKO](https://github.com/adobe-type-tools/afdko). As well as syntax highlighting, there are also a couple of snippets for creating features, tables etc.
 
 ## Installation
 


### PR DESCRIPTION
[The page](https://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html) looks dull right now, but @frankrolf is [working on converting it to markdown](https://github.com/adobe-type-tools/afdko/pull/776)